### PR TITLE
Display staff id in the purchase order confirmation

### DIFF
--- a/Purchasing System/PurchaseOrder/templates/PurchaseOrder/purchaseorderconfirmation.html
+++ b/Purchasing System/PurchaseOrder/templates/PurchaseOrder/purchaseorderconfirmation.html
@@ -18,7 +18,7 @@
             <div class="col">
                 <label class="labelpodetails fontlabel">Company Information</label>
               <textarea type="text" class="infobox" name="staff_info" readonly>{{staff.person_name}} &#13;&#10;{{staff.person_address}} &#13;&#10;{{staff.person_phone_number}}</textarea>
-                <input type="text" class="hideinfo" name="staff_id" value="{{staff.id}}">
+                <input type="text" class="hideinfo" name="staff_id" value="{{staff_id}}">
             </div>
             <div class="col">
                 <label class="labelpodetails fontlabel">Vendor Information</label>


### PR DESCRIPTION
Fixed a typo error that causes staff id not to display.